### PR TITLE
chore: add automatic module name

### DIFF
--- a/jar-jni/pom.xml
+++ b/jar-jni/pom.xml
@@ -40,4 +40,21 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.questdb.rust</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Maven Java Compiler places JARs will place JARs with an automatic module name in a manifest on a module path instead of a classpath so these JARs can be consumed by other modules.

An alternative would be to provide a full-blown module-info.java, but that would make the JAR JDK9+ only. An automatic module name is a good compromise: The JAR can target JDK8 and it still has an explicit module name, so Maven treats it as a module instead of a JAR on a classpath.