### PR TITLE
chore: Add a full Java module descriptor.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn package
+        run: mvn package -Dmoditect.skip=true
 
       - name: Runnig the example
         run: java -cp "./rust-maven-example/target/rust-maven-example-1.0.0-SNAPSHOT.jar${{ matrix.path-sep }}./jar-jni/target/jar-jni-1.0.0-SNAPSHOT.jar" io.questdb.example.rust.Main

--- a/jar-jni/pom.xml
+++ b/jar-jni/pom.xml
@@ -40,4 +40,39 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.RC2</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+                            <module>
+                                <moduleInfo>
+                                    <name>io.questdb.rust</name>
+                                    <!-- export everything -->
+                                    <exports>*;</exports>
+                                    <!-- declare services consumed by the artifact -->
+                                    <addServiceUses>true</addServiceUses>
+                                </moduleInfo>
+                            </module>
+                            <jdepsExtraArgs>
+                                <arg>--multi-release=9</arg>
+                            </jdepsExtraArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
supersedes #21

Using the ModiTect plugin allows the codebase to remain Java 8 while providing a full module descriptor that will be placed in the versioned space (META-INF/versions/9)