### PR TITLE
fix: Add support to legacy key crate_type used in cargo build file

### DIFF
--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/Crate.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/Crate.java
@@ -187,10 +187,8 @@ public class Crate {
 
     public boolean hasCdylib() {
         try {
-            TomlArray crateTypes = cargoToml.getArray("lib.crate-type");
-            if (crateTypes == null) {
-                return false;
-            }
+            TomlArray crateTypes = getCrateTypes();
+            if (crateTypes == null) return false;
 
             for (int index = 0; index < crateTypes.size(); index++) {
                 String crateType = crateTypes.getString(index);
@@ -203,6 +201,15 @@ public class Crate {
         } catch (TomlInvalidTypeException e) {
             return false;
         }
+    }
+
+    private TomlArray getCrateTypes() {
+        TomlArray crateTypes = cargoToml.getArray("lib.crate-type");
+        if (crateTypes == null) {
+            String crateTypeLegacyKey = "lib.crate_type";
+            return cargoToml.getArray(crateTypeLegacyKey);
+        }
+        return crateTypes;
     }
 
     private String getCdylibName() throws MojoExecutionException {

--- a/rust-maven-plugin/src/test/java/io/questdb/maven/rust/CrateTest.java
+++ b/rust-maven-plugin/src/test/java/io/questdb/maven/rust/CrateTest.java
@@ -244,6 +244,37 @@ public class CrateTest {
     }
 
     @Test
+    public void testCdylibLegacyKeyCrateType() throws Exception {
+        // Setting up mock Rust project directory.
+        final MockCrate mock = new MockCrate(
+                "test-lib-1",
+                "debug");
+        mock.writeCargoToml(
+                "[package]\n" +
+                "name = \"test-lib\"\n" +
+                "version = \"0.1.0\"\n" +
+                "edition = \"2021\"\n" +
+                "\n" +
+                "[lib]\n" +
+                "crate_type = [\"cdylib\"]\n");
+        mock.touchSrc("lib.rs");
+        final Path cdylibPath = mock.touchLib("test-lib");
+
+        // Configuring the build job.
+
+        final Crate crate = new Crate(
+                mock.crateRoot,
+                targetRootDir,
+                new Crate.Params());
+
+        // Checking the expected paths it generates.
+        final List<Path> artifacts = crate.getArtifactPaths();
+
+        assertEquals(1, artifacts.size());
+        assertEquals(cdylibPath, artifacts.get(0));
+    }
+
+    @Test
     public void testDefaultBinAndCdylib() throws Exception {
         // Setting up mock Rust project directory.
         final MockCrate mock = new MockCrate(


### PR DESCRIPTION
This resolves issue #28. 