### PR TITLE
feat: new configuration to skip a plugin execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,35 @@ Additional arguments to can go in the `<extra-args>` configuration section.
 </extra-args>
 ```
 
+## Skipping an execution
+
+If you need to skip an execution, you can set `<skip>true</skip>` in the
+`<configuration>` block of the `<execution>` of the plugin.
+
+```xml
+<skip>true</skip>  <!-- or `false`, the default value. -->
+```
+
+This is probably most useful when driven from a property.
+
+```xml
+<skip>${skipRustBuild}</skip>
+```
+
+The property can be defaulted in the `<properties>` section of the `pom.xml` file.
+
+```xml
+<properties>
+    <skipRustBuild>false</skipRustBuild>
+</properties>
+```
+
+And then overridden on the command line with `-DskipRustBuild=true`.
+
+```shell
+$ mvn package -DskipRustBuild=true
+```
+
 ## Overriding Environment Variables
 
 The plugin can be configured to override environment variables during the build.

--- a/jar-jni/pom.xml
+++ b/jar-jni/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.questdb</groupId>
     <artifactId>jar-jni</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JAR JNI Loader</name>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <groupId>org.questdb</groupId>
     <artifactId>rust-maven</artifactId>
     <packaging>pom</packaging>

--- a/rust-maven-jna-example/pom.xml
+++ b/rust-maven-jna-example/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.questdb</groupId>
     <artifactId>rust-maven-jna-example</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Rust Maven Plugin JNA Usage Example</name>

--- a/rust-maven-jni-example/pom.xml
+++ b/rust-maven-jni-example/pom.xml
@@ -22,12 +22,12 @@
   ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.questdb</groupId>
     <artifactId>rust-maven-jni-example</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Rust Maven Plugin Usage Example</name>
@@ -173,27 +173,6 @@
                         <!-- 
                             This is an example of how to skip an execution.
                             You can use this to skip both "build" and "test" executions.
-
-                            The example below configures
-
-                                <skip>true</skip>
-
-                            But you could use a property here too:
-
-                                <skip>${dummy.skip}</skip>
-
-                            If you wanted to always build unless specifed on the command line,
-                            you can default it in config in the properties section of your pom.xml:
-
-                                <properties>
-                                    <dummy.skip>false</dummy.skip>
-                                </properties>
-
-                            Then you can run:
-
-                                mvn clean package -Ddummy.skip=true
-
-                            To skip the specific execution.
                         -->
                         <id>dummy</id>
                         <goals>

--- a/rust-maven-jni-example/pom.xml
+++ b/rust-maven-jni-example/pom.xml
@@ -169,6 +169,41 @@
                             </environmentVariables>
                         </configuration>
                     </execution>
+                    <execution>
+                        <!-- 
+                            This is an example of how to skip an execution.
+                            You can use this to skip both "build" and "test" executions.
+
+                            The example below configures
+
+                                <skip>true</skip>
+
+                            But you could use a property here too:
+
+                                <skip>${dummy.skip}</skip>
+
+                            If you wanted to always build unless specifed on the command line,
+                            you can default it in config in the properties section of your pom.xml:
+
+                                <properties>
+                                    <dummy.skip>false</dummy.skip>
+                                </properties>
+
+                            Then you can run:
+
+                                mvn clean package -Ddummy.skip=true
+
+                            To skip the specific execution.
+                        -->
+                        <id>dummy</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                            <path>required, but not evaluated if skipped</path>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/rust-maven-plugin/pom.xml
+++ b/rust-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.questdb</groupId>
     <artifactId>rust-maven-plugin</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Rust Maven Plugin</name>

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoBuildMojo.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoBuildMojo.java
@@ -58,6 +58,10 @@ public class CargoBuildMojo extends CargoMojoBase {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping build");
+            return;
+        }
         final Crate crate = new Crate(
                 getCrateRoot(),
                 getTargetRootDir(),

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
@@ -48,6 +48,12 @@ public abstract class CargoMojoBase extends AbstractMojo {
     private String cargoPath;
 
     /**
+     * Skip this configured execution.
+     */
+    @Parameter(property = "skip", defaultValue = "false")
+    protected boolean skip;
+
+    /**
      * Path to the Rust crate to build.
      */
     @Parameter(property = "path", required = true)

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
@@ -38,6 +38,15 @@ public abstract class CargoMojoBase extends AbstractMojo {
     @Parameter(property = "project", readonly = true)
     protected MavenProject project;
 
+    /**
+     * Skip this configured execution.
+     */
+    @Parameter(property = "skip", defaultValue = "false")
+    protected boolean skip;
+
+    /**
+     * Additional environment variables set when running `cargo`.
+     */
     @Parameter(property = "environmentVariables")
     private HashMap<String, String> environmentVariables;
 
@@ -46,12 +55,6 @@ public abstract class CargoMojoBase extends AbstractMojo {
      */
     @Parameter(property = "cargoPath", defaultValue = "cargo")
     private String cargoPath;
-
-    /**
-     * Skip this configured execution.
-     */
-    @Parameter(property = "skip", defaultValue = "false")
-    protected boolean skip;
 
     /**
      * Path to the Rust crate to build.

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoTestMojo.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoTestMojo.java
@@ -40,7 +40,7 @@ public class CargoTestMojo extends CargoMojoBase {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (skipTests) {
+        if (skip || skipTests) {
             getLog().info("Skipping tests");
             return;
         }


### PR DESCRIPTION
Introduces a new `<skip>..</skip>` configuration option.

When set to `true` (default is `false`) the build or test execution is skipped.