### PR TITLE
fix: amd64 canonical arch name

### DIFF
--- a/jar-jni/src/main/java/io/questdb/jar/jni/Platform.java
+++ b/jar-jni/src/main/java/io/questdb/jar/jni/Platform.java
@@ -243,8 +243,8 @@ public final class Platform {
         else if ("i386".equals(arch) || "i686".equals(arch)) {
             arch = "x86";
         }
-        else if ("x86_64".equals(arch) || "amd64".equals(arch)) {
-            arch = "x86-64";
+        else if ("x86_64".equals(arch) || "x86-64".equals(arch)) {
+            arch = "amd64";
         }
         else if ("zarch_64".equals(arch)) {
             arch = "s390x";


### PR DESCRIPTION
The QuestDB project uses "amd64" as the name of the architecture for native libraries. Current rust-maven-plugin uses x86-64 instead. This results in a mismatch when building Rust for code coverage.

This PR changes the canonical arch name to "amd64".