### PR TITLE
feat: configurable target directory to share the cargo build cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,14 @@ $ mvn package -Drust.targetRootDir=$HOME/.cache/shared-rust-target
 ```
 
 Because every worktree resolves the same crate directory name under the shared root,
-they share one cargo target directory. Cargo holds an exclusive lock on it, so parallel
-builds across worktrees are serialized rather than corrupting each other; the final
-artifacts are still copied into each checkout's own `<copyTo>` location.
+they share one cargo target directory. To keep that safe, the plugin takes its own
+exclusive lock (a lock file next to the target directory) spanning the whole build and
+the subsequent artifact copy - not just the `cargo` invocation. This matters because
+cargo leaves the final artifact under `<profile>` un-fingerprinted and releases its own
+lock as soon as it exits, so without the plugin lock a second checkout could overwrite
+that artifact in the window before the first checkout copies it. Builds and tests across
+worktrees are therefore serialized rather than clobbering each other, and each checkout's
+artifacts are copied into its own `<copyTo>` location.
 
 Note: a shared directory set outside `${project.build.directory}` is **not** removed by
 `mvn clean` (see below).

--- a/README.md
+++ b/README.md
@@ -251,11 +251,47 @@ In the `<configuration>` section, add:
 </environmentVariables>
 ```
 
+## Overriding the cargo target directory
+
+By default the plugin builds into `${project.build.directory}/rust-maven-plugin`
+(i.e. inside Maven's `target` directory). Set `<targetRootDir>` to build somewhere
+else. The plugin appends the crate's directory name and passes the result to cargo
+as `--target-dir`.
+
+```xml
+<targetRootDir>${project.build.directory}/rust-maven-plugin</targetRootDir>
+```
+
+The main use case is **sharing compiled dependencies across checkouts**. If you keep
+several git worktrees (or sibling clones) of the same project, each one otherwise gets
+its own copy of every compiled dependency, which recompiles and re-stores gigabytes of
+identical crates per checkout. Pointing them all at one shared directory - typically
+via a property so it can live outside any single checkout - makes cargo reuse the same
+`deps/` across all of them:
+
+```xml
+<targetRootDir>${rust.targetRootDir}</targetRootDir>
+```
+
+```shell
+$ mvn package -Drust.targetRootDir=$HOME/.cache/shared-rust-target
+```
+
+Because every worktree resolves the same crate directory name under the shared root,
+they share one cargo target directory. Cargo holds an exclusive lock on it, so parallel
+builds across worktrees are serialized rather than corrupting each other; the final
+artifacts are still copied into each checkout's own `<copyTo>` location.
+
+Note: a shared directory set outside `${project.build.directory}` is **not** removed by
+`mvn clean` (see below).
+
 # Cleaning the Rust build
 
 Regular `mvn clean` will also clean the Rust build without additional config.
-This is because the plugin builds crates inside Maven's `target` build
-directory, via `cargo build --target-dir ...`.
+This is because the plugin, by default, builds crates inside Maven's `target`
+build directory, via `cargo build --target-dir ...`. A `<targetRootDir>` pointed
+outside `target` (for example a shared directory, see above) is not cleaned by
+`mvn clean`.
 
 # De-duplicating build directories when invoking `cargo build` without Maven
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,10 @@ $ mvn package -Drust.targetRootDir=$HOME/.cache/shared-rust-target
 Because every worktree resolves the same crate directory name under the shared root,
 they share one cargo target directory. To keep that safe, the plugin takes its own
 exclusive lock (a lock file next to the target directory) spanning the whole build and
-the subsequent artifact copy - not just the `cargo` invocation. This matters because
+the subsequent artifact copy - not just the `cargo` invocation. The lock engages only
+when `targetRootDir` points outside `${project.build.directory}` (i.e. a shared or
+otherwise non-default directory); a conventional single-checkout build takes no lock and
+is unaffected. This matters because
 cargo leaves the final artifact under `<profile>` un-fingerprinted and releases its own
 lock as soon as it exits, so without the plugin lock a second **plugin-driven** build
 could overwrite that artifact in the window before the first one copies it. Builds and

--- a/README.md
+++ b/README.md
@@ -282,10 +282,21 @@ they share one cargo target directory. To keep that safe, the plugin takes its o
 exclusive lock (a lock file next to the target directory) spanning the whole build and
 the subsequent artifact copy - not just the `cargo` invocation. This matters because
 cargo leaves the final artifact under `<profile>` un-fingerprinted and releases its own
-lock as soon as it exits, so without the plugin lock a second checkout could overwrite
-that artifact in the window before the first checkout copies it. Builds and tests across
-worktrees are therefore serialized rather than clobbering each other, and each checkout's
-artifacts are copied into its own `<copyTo>` location.
+lock as soon as it exits, so without the plugin lock a second **plugin-driven** build
+could overwrite that artifact in the window before the first one copies it. Builds and
+tests driven by the plugin across worktrees are therefore serialized rather than
+clobbering each other, and each checkout's artifacts are copied into its own `<copyTo>`
+location.
+
+**Scope of the lock.** It only coordinates builds that go through this plugin - it is an
+ordinary advisory lock file that a plain `cargo build`/`test`, or an IDE / rust-analyzer,
+knows nothing about. Do not point a concurrent raw `cargo` invocation at a *shared* target
+directory: it can overwrite the final artifact in the copy window regardless of the lock.
+In practice tools use their own target directory by default (an IDE or rust-analyzer does
+not build into the plugin's `--target-dir` unless you configure it to, e.g. via
+`.cargo/config.toml`), so this is only a concern if you deliberately share the directory
+with non-Maven builds. A fully writer-agnostic fix awaits cargo's `--artifact-dir` (copy
+the final artifact straight to a private directory), which is still nightly-only.
 
 Note: a shared directory set outside `${project.build.directory}` is **not** removed by
 `mvn clean` (see below).

--- a/README.md
+++ b/README.md
@@ -325,6 +325,12 @@ passed by this plugin.
 See [.cargo/config.toml](rust-maven-jni-example/src/main/rust/str-reverse/.cargo/config.toml)
 from the `str-reverse` crate in the example.
 
+Only do this when the plugin builds into the crate's **own** (default) target
+directory. Do **not** point `.cargo/config.toml` at a *shared* `targetRootDir`
+(see [Overriding the cargo target directory](#overriding-the-cargo-target-directory)):
+that would make your IDE / raw `cargo` builds write into the shared directory
+concurrently with plugin builds, which the plugin's lock cannot guard against.
+
 # Bundling binaries in the `.jar` file
 
 The `<copyTo>` configuration (as shown in the example) allows copying the

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoBuildMojo.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoBuildMojo.java
@@ -67,8 +67,13 @@ public class CargoBuildMojo extends CargoMojoBase {
                 getTargetRootDir(),
                 extractCrateParams());
         crate.setLog(getLog());
-        crate.build();
-        crate.copyArtifacts();
+        // Lock spans both the build and the copy: cargo leaves the (non-fingerprinted)
+        // final artifact in the target dir, and a concurrent build sharing that dir could
+        // overwrite it between `cargo` exiting and copyArtifacts() reading it.
+        try (TargetDirLock ignored = crate.lockTargetDir()) {
+            crate.build();
+            crate.copyArtifacts();
+        }
     }
 
     private Crate.Params extractCrateParams() throws MojoExecutionException {

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoBuildMojo.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoBuildMojo.java
@@ -67,10 +67,11 @@ public class CargoBuildMojo extends CargoMojoBase {
                 getTargetRootDir(),
                 extractCrateParams());
         crate.setLog(getLog());
-        // Lock spans both the build and the copy: cargo leaves the (non-fingerprinted)
-        // final artifact in the target dir, and a concurrent build sharing that dir could
-        // overwrite it between `cargo` exiting and copyArtifacts() reading it.
-        try (TargetDirLock ignored = crate.lockTargetDir()) {
+        // For a shared target dir the lock spans both the build and the copy: cargo
+        // leaves the (non-fingerprinted) final artifact in the target dir, and a
+        // concurrent plugin build sharing that dir could overwrite it between `cargo`
+        // exiting and copyArtifacts() reading it. No-op for a private target dir.
+        try (TargetDirLock ignored = crate.lockTargetDir(isSharedTargetDir())) {
             crate.build();
             crate.copyArtifacts();
         }

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
@@ -119,7 +119,9 @@ public abstract class CargoMojoBase extends AbstractMojo {
      * single shared directory to reuse compiled dependencies across builds instead of
      * recompiling and re-storing the same crates for each checkout. When a directory is
      * shared, the plugin serializes builds against it with its own lock (see
-     * `TargetDirLock`) so concurrent builds cannot overwrite each other's artifacts.
+     * `TargetDirLock`) so concurrent plugin-driven builds cannot overwrite each other's
+     * artifacts. That lock does not coordinate with raw `cargo` runs outside the plugin,
+     * so do not point a concurrent standalone `cargo` build at a shared directory.
      * Note that a shared directory set outside `${project.build.directory}` is no longer
      * removed by `mvn clean`.
      */

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
@@ -107,6 +107,26 @@ public abstract class CargoMojoBase extends AbstractMojo {
     @Parameter(property = "extra-args")
     private String[] extraArgs;
 
+    /**
+     * Root directory for cargo's build output, passed to cargo as the
+     * `--target-dir` argument (with the crate's directory name appended).
+     * <p>
+     * Defaults to `${project.build.directory}/rust-maven-plugin`, which keeps the
+     * Rust build output inside Maven's `target` directory (and therefore cleaned by
+     * `mvn clean`).
+     * <p>
+     * Point multiple projects - or multiple git worktrees of the same project - at a
+     * single shared directory to reuse compiled dependencies across builds instead of
+     * recompiling and re-storing the same crates for each checkout. Cargo takes an
+     * exclusive lock on the target directory, so concurrent builds are serialized
+     * rather than corrupting each other. Note that a shared directory set outside
+     * `${project.build.directory}` is no longer removed by `mvn clean`.
+     */
+    @Parameter(
+            property = "targetRootDir",
+            defaultValue = "${project.build.directory}/rust-maven-plugin")
+    private String targetRootDir;
+
     protected String getVerbosity() throws MojoExecutionException {
         if (verbosity == null) {
             return null;
@@ -132,9 +152,12 @@ public abstract class CargoMojoBase extends AbstractMojo {
     }
 
     protected Path getTargetRootDir() {
-        return Paths.get(
-                project.getBuild().getDirectory(),
-                "rust-maven-plugin");
+        if ((targetRootDir == null) || targetRootDir.trim().isEmpty()) {
+            return Paths.get(
+                    project.getBuild().getDirectory(),
+                    "rust-maven-plugin");
+        }
+        return Paths.get(targetRootDir);
     }
 
     protected Crate.Params getCommonCrateParams() throws MojoExecutionException {

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
@@ -163,6 +163,18 @@ public abstract class CargoMojoBase extends AbstractMojo {
         return Paths.get(targetRootDir);
     }
 
+    /**
+     * Whether the configured target root is a shared directory, i.e. not the module's
+     * own directory under `${project.build.directory}`. The build lock only engages for
+     * shared directories, so a conventional single-checkout build is unaffected.
+     */
+    protected boolean isSharedTargetDir() {
+        final Path root = getTargetRootDir().toAbsolutePath().normalize();
+        final Path buildDir = Paths.get(project.getBuild().getDirectory())
+                .toAbsolutePath().normalize();
+        return !root.startsWith(buildDir);
+    }
+
     protected Crate.Params getCommonCrateParams() throws MojoExecutionException {
         final Crate.Params params = new Crate.Params();
         params.verbosity = getVerbosity();

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
@@ -155,12 +155,24 @@ public abstract class CargoMojoBase extends AbstractMojo {
     }
 
     protected Path getTargetRootDir() {
-        if ((targetRootDir == null) || targetRootDir.trim().isEmpty()) {
-            return Paths.get(
-                    project.getBuild().getDirectory(),
-                    "rust-maven-plugin");
+        return resolveTargetRootDir(
+                targetRootDir,
+                project.getBasedir().toPath(),
+                project.getBuild().getDirectory());
+    }
+
+    /**
+     * Resolves the configured `targetRootDir` value. An unset/blank value defaults to
+     * `<buildDirectory>/rust-maven-plugin`; a relative value is resolved against the
+     * module `basedir` (consistently with `path` and `copyTo`) rather than against
+     * Maven's launch directory; an absolute value is used as-is.
+     */
+    static Path resolveTargetRootDir(String configured, Path basedir, String buildDirectory) {
+        if ((configured == null) || configured.trim().isEmpty()) {
+            return Paths.get(buildDirectory, "rust-maven-plugin");
         }
-        return Paths.get(targetRootDir);
+        final Path root = Paths.get(configured);
+        return root.isAbsolute() ? root : basedir.resolve(root);
     }
 
     /**

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoMojoBase.java
@@ -117,10 +117,11 @@ public abstract class CargoMojoBase extends AbstractMojo {
      * <p>
      * Point multiple projects - or multiple git worktrees of the same project - at a
      * single shared directory to reuse compiled dependencies across builds instead of
-     * recompiling and re-storing the same crates for each checkout. Cargo takes an
-     * exclusive lock on the target directory, so concurrent builds are serialized
-     * rather than corrupting each other. Note that a shared directory set outside
-     * `${project.build.directory}` is no longer removed by `mvn clean`.
+     * recompiling and re-storing the same crates for each checkout. When a directory is
+     * shared, the plugin serializes builds against it with its own lock (see
+     * `TargetDirLock`) so concurrent builds cannot overwrite each other's artifacts.
+     * Note that a shared directory set outside `${project.build.directory}` is no longer
+     * removed by `mvn clean`.
      */
     @Parameter(
             property = "targetRootDir",

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoTestMojo.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoTestMojo.java
@@ -49,6 +49,10 @@ public class CargoTestMojo extends CargoMojoBase {
                 getTargetRootDir(),
                 getCommonCrateParams());
         crate.setLog(getLog());
-        crate.test();
+        // Share the same lock as `build` so tests and builds across checkouts that share
+        // a target directory are serialized rather than clobbering each other's output.
+        try (TargetDirLock ignored = crate.lockTargetDir()) {
+            crate.test();
+        }
     }
 }

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoTestMojo.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/CargoTestMojo.java
@@ -50,8 +50,9 @@ public class CargoTestMojo extends CargoMojoBase {
                 getCommonCrateParams());
         crate.setLog(getLog());
         // Share the same lock as `build` so tests and builds across checkouts that share
-        // a target directory are serialized rather than clobbering each other's output.
-        try (TargetDirLock ignored = crate.lockTargetDir()) {
+        // a target directory are serialized rather than clobbering each other's output
+        // (a `cargo test` rebuilds the crate too). No-op for a private target dir.
+        try (TargetDirLock ignored = crate.lockTargetDir(isSharedTargetDir())) {
             crate.test();
         }
     }

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/Crate.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/Crate.java
@@ -420,6 +420,18 @@ public class Crate {
         }
     }
 
+    /**
+     * Acquires an exclusive lock over this crate's cargo target directory, blocking
+     * until it is available. The caller must hold it across {@link #build()} and
+     * {@link #copyArtifacts()} (or {@link #test()}) so that a concurrent build sharing
+     * the same target directory cannot overwrite the final artifact before it is copied.
+     * See {@link TargetDirLock} for details.
+     */
+    public TargetDirLock lockTargetDir() throws MojoExecutionException {
+        log.info("Acquiring exclusive lock on target dir: " + targetDir.toAbsolutePath());
+        return TargetDirLock.acquire(targetDir);
+    }
+
     public void build() throws MojoExecutionException, MojoFailureException {
         List<String> args = new ArrayList<>();
         args.add("build");

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/Crate.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/Crate.java
@@ -426,9 +426,16 @@ public class Crate {
      * {@link #copyArtifacts()} (or {@link #test()}) so that a concurrent build sharing
      * the same target directory cannot overwrite the final artifact before it is copied.
      * See {@link TargetDirLock} for details.
+     * <p>
+     * When {@code shared} is false the target directory is private to this build, so the
+     * returned lock is a no-op and the build is not serialized.
      */
-    public TargetDirLock lockTargetDir() throws MojoExecutionException {
-        log.info("Acquiring exclusive lock on target dir: " + targetDir.toAbsolutePath());
+    public TargetDirLock lockTargetDir(boolean shared) throws MojoExecutionException {
+        if (!shared) {
+            return TargetDirLock.disabled();
+        }
+        log.info("Acquiring exclusive lock on shared target dir: "
+                + targetDir.toAbsolutePath());
         return TargetDirLock.acquire(targetDir);
     }
 

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/TargetDirLock.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/TargetDirLock.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2023 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.maven.rust;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Exclusive lock guarding a single cargo target directory across a whole
+ * build-and-copy (or test) critical section.
+ * <p>
+ * When several checkouts share one target directory (see the plugin's
+ * `targetRootDir` parameter), cargo already serializes the builds themselves via
+ * its own lock, but it releases that lock as soon as it exits. The final artifact
+ * cargo leaves in the `<profile>` directory is not fingerprinted, so a second
+ * checkout could overwrite it in the window between `cargo` exiting and this plugin
+ * copying the artifact to its own destination - silently packaging another
+ * checkout's binary. Holding this lock from before `cargo` starts until after the
+ * copy completes closes that window.
+ * <p>
+ * The lock is both cross-process (an OS {@link FileLock}) and in-JVM (a
+ * {@link ReentrantLock}). The in-JVM lock is required because a `FileLock` is owned
+ * by the whole JVM: two threads in the same reactor (e.g. a parallel `mvn -T` build)
+ * would otherwise race to lock the same file and hit an
+ * `OverlappingFileLockException` instead of being serialized.
+ */
+final class TargetDirLock implements AutoCloseable {
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS =
+            new ConcurrentHashMap<>();
+
+    private final ReentrantLock jvmLock;
+    private final FileChannel channel;
+    private final FileLock fileLock;
+
+    private TargetDirLock(ReentrantLock jvmLock, FileChannel channel, FileLock fileLock) {
+        this.jvmLock = jvmLock;
+        this.channel = channel;
+        this.fileLock = fileLock;
+    }
+
+    /**
+     * Acquires the lock for the given cargo target directory, blocking until it is
+     * available. The lock file lives next to the target directory (not inside it, so
+     * it never interferes with cargo's management of the directory's contents) and is
+     * named after it, so checkouts sharing a target directory contend on the same file.
+     */
+    static TargetDirLock acquire(Path targetDir) throws MojoExecutionException {
+        final Path parent = targetDir.toAbsolutePath().getParent();
+        final Path lockFile = parent.resolve(targetDir.getFileName().toString() + ".lock");
+        final ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockFile, k -> new ReentrantLock());
+        jvmLock.lock();
+        try {
+            Files.createDirectories(parent);
+            final FileChannel channel = FileChannel.open(
+                    lockFile,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE);
+            try {
+                final FileLock fileLock = channel.lock();
+                return new TargetDirLock(jvmLock, channel, fileLock);
+            } catch (IOException e) {
+                channel.close();
+                throw e;
+            }
+        } catch (IOException e) {
+            jvmLock.unlock();
+            throw new MojoExecutionException(
+                    "Failed to acquire build lock for target directory " + targetDir, e);
+        }
+    }
+
+    @Override
+    public void close() throws MojoExecutionException {
+        try {
+            fileLock.release();
+            channel.close();
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to release build lock", e);
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+}

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/TargetDirLock.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/TargetDirLock.java
@@ -64,6 +64,9 @@ final class TargetDirLock implements AutoCloseable {
     private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS =
             new ConcurrentHashMap<>();
 
+    /** A no-op lock, used when the target directory is private to this build. */
+    private static final TargetDirLock DISABLED = new TargetDirLock(null, null, null);
+
     private final ReentrantLock jvmLock;
     private final FileChannel channel;
     private final FileLock fileLock;
@@ -72,6 +75,11 @@ final class TargetDirLock implements AutoCloseable {
         this.jvmLock = jvmLock;
         this.channel = channel;
         this.fileLock = fileLock;
+    }
+
+    /** Returns a lock that does nothing; for target directories that are not shared. */
+    static TargetDirLock disabled() {
+        return DISABLED;
     }
 
     /**
@@ -107,6 +115,9 @@ final class TargetDirLock implements AutoCloseable {
 
     @Override
     public void close() throws MojoExecutionException {
+        if (fileLock == null) {
+            return;
+        }
         try {
             fileLock.release();
             channel.close();

--- a/rust-maven-plugin/src/main/java/io/questdb/maven/rust/TargetDirLock.java
+++ b/rust-maven-plugin/src/main/java/io/questdb/maven/rust/TargetDirLock.java
@@ -53,6 +53,12 @@ import java.util.concurrent.locks.ReentrantLock;
  * by the whole JVM: two threads in the same reactor (e.g. a parallel `mvn -T` build)
  * would otherwise race to lock the same file and hit an
  * `OverlappingFileLockException` instead of being serialized.
+ * <p>
+ * Scope: this is an advisory lock file that only invocations of this plugin acquire.
+ * It does not coordinate with a standalone `cargo` build (or an IDE / rust-analyzer)
+ * run against the same target directory; such a build can still overwrite the final
+ * artifact in the copy window. Tools use their own target directory by default, so a
+ * shared directory should only ever be built into by this plugin.
  */
 final class TargetDirLock implements AutoCloseable {
     private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS =

--- a/rust-maven-plugin/src/test/java/io/questdb/maven/rust/CrateTest.java
+++ b/rust-maven-plugin/src/test/java/io/questdb/maven/rust/CrateTest.java
@@ -631,6 +631,35 @@ public class CrateTest {
                 acquired.get());
     }
 
+    @Test
+    public void testResolveTargetRootDirDefault() {
+        final Path base = tmpDir.getRoot().toPath();
+        final Path buildDir = base.resolve("target");
+        final Path expected = buildDir.resolve("rust-maven-plugin");
+        assertEquals(expected,
+                CargoMojoBase.resolveTargetRootDir(null, base, buildDir.toString()));
+        assertEquals(expected,
+                CargoMojoBase.resolveTargetRootDir("   ", base, buildDir.toString()));
+    }
+
+    @Test
+    public void testResolveTargetRootDirRelativeIsResolvedAgainstBasedir() {
+        final Path base = tmpDir.getRoot().toPath().toAbsolutePath();
+        final Path resolved = CargoMojoBase.resolveTargetRootDir(
+                "shared-target", base, base.resolve("target").toString());
+        // Resolved against the module, not the (arbitrary) process working directory.
+        assertTrue(resolved.isAbsolute());
+        assertEquals(base.resolve("shared-target"), resolved);
+    }
+
+    @Test
+    public void testResolveTargetRootDirAbsoluteIsKept() {
+        final Path base = tmpDir.getRoot().toPath().toAbsolutePath();
+        final Path absolute = base.resolve("elsewhere").resolve("shared").toAbsolutePath();
+        assertEquals(absolute, CargoMojoBase.resolveTargetRootDir(
+                absolute.toString(), base, base.resolve("target").toString()));
+    }
+
     private static void writeCdylibToml(Path crateRoot, String name) throws IOException {
         writeFile(crateRoot.resolve("Cargo.toml"),
                 "[package]\n" +

--- a/rust-maven-plugin/src/test/java/io/questdb/maven/rust/CrateTest.java
+++ b/rust-maven-plugin/src/test/java/io/questdb/maven/rust/CrateTest.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.*;
 
@@ -598,6 +599,36 @@ public class CrateTest {
         assertNotEquals(
                 new Crate(worktreeA, rootA, new Crate.Params()).getArtifactPaths().get(0),
                 new Crate(worktreeB, rootB, new Crate.Params()).getArtifactPaths().get(0));
+    }
+
+    @Test
+    public void testTargetDirLockIsExclusive() throws Exception {
+        final Path targetDir = tmpDir.newFolder("shared", "rust").toPath();
+
+        final TargetDirLock held = TargetDirLock.acquire(targetDir);
+
+        // The lock file lives next to the target dir so shared checkouts contend on it.
+        assertTrue(Files.exists(targetDir.resolveSibling("rust.lock")));
+
+        // A second acquisition from another thread must block while the first is held.
+        final AtomicBoolean acquired = new AtomicBoolean(false);
+        final Thread contender = new Thread(() -> {
+            try (TargetDirLock ignored = TargetDirLock.acquire(targetDir)) {
+                acquired.set(true);
+            } catch (MojoExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        contender.start();
+        contender.join(500);
+        assertFalse("second lock must not be acquired while the first is held",
+                acquired.get());
+
+        held.close();
+        contender.join(5000);
+        assertFalse(contender.isAlive());
+        assertTrue("second lock must be acquired once the first is released",
+                acquired.get());
     }
 
     private static void writeCdylibToml(Path crateRoot, String name) throws IOException {

--- a/rust-maven-plugin/src/test/java/io/questdb/maven/rust/CrateTest.java
+++ b/rust-maven-plugin/src/test/java/io/questdb/maven/rust/CrateTest.java
@@ -570,6 +570,47 @@ public class CrateTest {
                 () -> new Crate(mock.crateRoot, targetRootDir, params));
     }
 
+    @Test
+    public void testSharedTargetRootDirIsReusedAcrossCheckouts() throws Exception {
+        // Two "worktrees" of the same project: distinct crate roots that share the
+        // same crate directory name ("rust"), exactly as git worktrees would.
+        final Path worktreeA = tmpDir.newFolder("worktreeA", "rust").toPath();
+        final Path worktreeB = tmpDir.newFolder("worktreeB", "rust").toPath();
+        writeCdylibToml(worktreeA, "opchain");
+        writeCdylibToml(worktreeB, "opchain");
+
+        final Path sharedRoot = tmpDir.newFolder("shared", "rust-maven-plugin").toPath();
+
+        final Crate crateA = new Crate(worktreeA, sharedRoot, new Crate.Params());
+        final Crate crateB = new Crate(worktreeB, sharedRoot, new Crate.Params());
+
+        // Both checkouts resolve to the same cargo target dir under the shared root,
+        // so their compiled dependencies are stored once rather than duplicated.
+        final Path libA = crateA.getArtifactPaths().get(0);
+        final Path libB = crateB.getArtifactPaths().get(0);
+        assertEquals(libB, libA);
+        assertTrue(libA.startsWith(sharedRoot));
+        assertEquals(sharedRoot.resolve("rust"), libA.getParent().getParent());
+
+        // Sanity: the default of a distinct root per checkout does NOT share.
+        final Path rootA = tmpDir.newFolder("perCheckoutA").toPath();
+        final Path rootB = tmpDir.newFolder("perCheckoutB").toPath();
+        assertNotEquals(
+                new Crate(worktreeA, rootA, new Crate.Params()).getArtifactPaths().get(0),
+                new Crate(worktreeB, rootB, new Crate.Params()).getArtifactPaths().get(0));
+    }
+
+    private static void writeCdylibToml(Path crateRoot, String name) throws IOException {
+        writeFile(crateRoot.resolve("Cargo.toml"),
+                "[package]\n" +
+                        "name = \"" + name + "\"\n" +
+                        "version = \"0.1.0\"\n" +
+                        "edition = \"2021\"\n" +
+                        "\n" +
+                        "[lib]\n" +
+                        "crate-type = [\"cdylib\"]\n");
+    }
+
     private static void writeFile(Path dest, String contents) throws IOException {
         try (PrintWriter w = new PrintWriter(dest.toFile(), "UTF-8")) {
             w.write(contents);


### PR DESCRIPTION
## Summary

Adds a `targetRootDir` parameter that controls the directory the plugin passes to
cargo as `--target-dir` (the crate's directory name is appended, as before).

It defaults to the current `${project.build.directory}/rust-maven-plugin`, so
existing builds are completely unaffected.

## Motivation

Today the target directory is hardcoded under Maven's `target/`, and cargo's
`--target-dir` is passed explicitly, so it can't be relocated via `CARGO_TARGET_DIR`,
`~/.cargo/config.toml`, or `<extra-args>` (cargo rejects a duplicate `--target-dir`).

When you keep several git worktrees (or sibling clones) of the same project, each one
gets its own full copy of every compiled dependency. For a project with a large Rust
dependency tree (e.g. a debug build of Arrow/DataFusion) that is several GB *per
checkout*, and the dependencies are identical across checkouts.

Pointing every checkout at one shared `targetRootDir` lets cargo store and reuse a
single `deps/` for all of them:

```xml
<targetRootDir>${rust.targetRootDir}</targetRootDir>
```

```shell
mvn package -Drust.targetRootDir=$HOME/.cache/shared-rust-target
```

## Concurrency safety (and its limits)

Sharing a target directory introduces a race: cargo leaves the final artifact under
`<profile>` **un-fingerprinted** and releases its own build lock as soon as it exits, so
a second checkout could overwrite that artifact in the window between the first
checkout's `cargo` exiting and the plugin copying it out — silently packaging the wrong
binary.

To close this for plugin-driven builds, the plugin takes its own lock spanning the whole
build-and-copy (and test) critical section — `TargetDirLock`, both an OS file lock and an
in-JVM `ReentrantLock` (so a parallel `mvn -T` reactor doesn't hit
`OverlappingFileLockException`). **The lock only engages when `targetRootDir` is outside
`${project.build.directory}`**, so conventional single-checkout builds take no lock and
see no behavior change. Because cargo already serializes the compile, the only added
serialization is the fast copy step.

Honest scope: this lock is advisory and only coordinates builds that go through the
plugin. A concurrent standalone `cargo build`/`test` (or an IDE / rust-analyzer) pointed
at the *same shared directory* can still overwrite the artifact in the copy window. In
practice such tools use their own target directory by default, so this only matters if
you deliberately share the directory with non-Maven builds. A fully writer-agnostic fix
awaits cargo's `--artifact-dir` (copy the final artifact straight to a private
directory), which is still nightly-only. This is documented in the README.

The locking is a self-contained commit; if you'd rather not carry it, it can be dropped
independently of the `targetRootDir` parameter.

## Changes

- `CargoMojoBase`: new `targetRootDir` `@Parameter` (default preserves current path);
  `getTargetRootDir()` returns it, falling back to the previous computed path when
  unset/blank; `isSharedTargetDir()` decides whether to lock.
- `Crate` / `TargetDirLock`: exclusive lock over the target directory, held across
  build+copy (and test), no-op when the directory is not shared.
- `CargoBuildMojo` / `CargoTestMojo`: acquire the (conditional) lock around the
  critical section.
- `CrateTest`: regression tests for the shared-directory resolution and for the lock's
  mutual exclusion.
- `README.md`: documents the parameter, the shared-cache use case, the lock, its scope,
  and the `mvn clean` interaction.

## Testing

- `mvn -pl rust-maven-plugin test` — 22/22 pass.
- End-to-end: built an example with `-DtargetRootDir=<tmp>` and confirmed cargo wrote
  into the override dir (namespaced per crate) with lock files present; a default build
  wrote no lock file; artifacts were bundled into the jar in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
